### PR TITLE
Fix typos

### DIFF
--- a/OperationResult/Result.cs
+++ b/OperationResult/Result.cs
@@ -15,9 +15,9 @@ namespace OperationResult
         public bool IsSuccess => _isSuccess;
         public bool IsError => !_isSuccess;
 
-        private Result(bool isSuccsess)
+        private Result(bool isSuccess)
         {
-            _isSuccess = isSuccsess;
+            _isSuccess = isSuccess;
             Value = default(TResult);
         }
 

--- a/OperationResult/Status.cs
+++ b/OperationResult/Status.cs
@@ -12,9 +12,9 @@ namespace OperationResult
         public bool IsSuccess => _isSuccess;
         public bool IsError => !_isSuccess;
 
-        private Status(bool isSuccsess)
+        private Status(bool isSuccess)
         {
-            _isSuccess = isSuccsess;
+            _isSuccess = isSuccess;
         }
 
         public static implicit operator bool(Status status)
@@ -50,9 +50,9 @@ namespace OperationResult
         public bool IsSuccess => _isSuccess;
         public bool IsError => !_isSuccess;
 
-        private Status(bool isSuccsess)
+        private Status(bool isSuccess)
         {
-            _isSuccess = isSuccsess;
+            _isSuccess = isSuccess;
             Error = default(TError);
         }
 
@@ -97,9 +97,9 @@ namespace OperationResult
         public bool HasError<TError>() => Error is TError;
         public TError GetError<TError>() => (TError)Error;
 
-        private Status(bool IsSuccess)
+        private Status(bool isSuccess)
         {
-            _isSuccess = IsSuccess;
+            _isSuccess = isSuccess;
             Error = null;
         }
 
@@ -151,9 +151,9 @@ namespace OperationResult
         public bool HasError<TError>() => Error is TError;
         public TError GetError<TError>() => (TError)Error;
 
-        private Status(bool IsSuccess)
+        private Status(bool isSuccess)
         {
-            _isSuccess = IsSuccess;
+            _isSuccess = isSuccess;
             Error = null;
         }
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ public struct Result<TResult>
     public readonly TResult Value;
 
     public bool IsError { get; }
-    public bool IsSuccsess { get; }
+    public bool IsSuccess { get; }
 
     public static implicit operator bool(Result<TResult> result);
     public static implicit operator Result<TResult>(TResult result);
@@ -88,7 +88,7 @@ public struct Result<TResult, TError>
     public readonly TResult Value;
 
     public bool IsError { get; }
-    public bool IsSuccsess { get; }
+    public bool IsSuccess { get; }
 
     public void Deconstruct(out TResult result, out TError error);
 
@@ -126,7 +126,7 @@ public struct Result<TResult, TError1, TError2, ...>
     public readonly TResult Value;
 
     public bool IsError { get; }
-    public bool IsSuccsess { get; }
+    public bool IsSuccess { get; }
 
     public void Deconstruct(out TResult result, out object error);
     
@@ -176,7 +176,7 @@ Status of some operation without result when there is no `TError` type defined
 public struct Status
 {
     public bool IsError { get; }
-    public bool IsSuccsess { get; }
+    public bool IsSuccess { get; }
 
     public static implicit operator bool(Status status);
 }
@@ -202,7 +202,7 @@ public struct Status<TError>
     public readonly TError Error;
 
     public bool IsError { get; }
-    public bool IsSuccsess { get; }
+    public bool IsSuccess { get; }
 
     public static implicit operator bool(Status<TError> status);
 }


### PR DESCRIPTION
Changed `isSuccess` parameters to `isSuccess` and `IsSuccsess` properties to `IsSuccess`.

Note: This is breaking change since `IsSuccsess` is public property.